### PR TITLE
feat(dashboard): add dashboard list and export commands

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// DashboardCmd represents the dashboard subcommand
+var DashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "dashboard operations",
+	Long:  `dashboard operations`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		// print help
+		cmd.Help() //nolint:errcheck
+		os.Exit(1)
+	},
+}

--- a/cmd/dashboard_export.go
+++ b/cmd/dashboard_export.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sgaunet/zabbix-cli/pkg/zabbix"
+	"github.com/spf13/cobra"
+)
+
+var DashboardExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export dashboard to YAML",
+	Long:  `Export a dashboard to YAML format. You can specify the dashboard by name or ID.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		// Validate that at least one of name or ID is provided
+		if dashboardName == "" && dashboardID == "" {
+			return fmt.Errorf("either --name or --id must be specified")
+		}
+
+		// Validate that both are not provided
+		if dashboardName != "" && dashboardID != "" {
+			return fmt.Errorf("cannot specify both --name and --id")
+		}
+
+		// initConfig() should be called by cobra.OnInitialize on the RootCmd.
+		if conf == nil {
+			return fmt.Errorf("configuration not initialized; initConfig did not run or failed")
+		}
+
+		z := zabbix.New(conf.ZabbixUser, conf.ZabbixPassword, conf.ZabbixEndpoint)
+		if err := z.Login(ctx); err != nil {
+			return fmt.Errorf("login failed: %w", err)
+		}
+		defer func() {
+			if err := z.Logout(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "logout failed: %v\n", err)
+			}
+		}()
+
+		// Find dashboard by name or ID
+		var dashboardIDToExport string
+		if dashboardName != "" {
+			// Search by name
+			filter := map[string]interface{}{
+				"name": dashboardName,
+			}
+			req := zabbix.NewDashboardGetRequest(
+				zabbix.WithDashboardGetAuth(z.Auth()),
+				zabbix.WithDashboardGetID(1),
+				zabbix.WithDashboardGetOutput("extend"),
+				zabbix.WithDashboardGetFilter(filter),
+			)
+
+			response, err := z.DashboardGet(ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to get dashboard by name: %w", err)
+			}
+
+			if len(response.Result) == 0 {
+				return fmt.Errorf("dashboard with name '%s' not found", dashboardName)
+			}
+
+			if len(response.Result) > 1 {
+				return fmt.Errorf("multiple dashboards found with name '%s', please use --id instead", dashboardName)
+			}
+
+			dashboardIDToExport = response.Result[0].DashboardID
+		} else {
+			// Use provided ID
+			dashboardIDToExport = dashboardID
+		}
+
+		// Export the dashboard
+		res, err := z.Export(ctx,
+			zabbix.ExportRequestOptionYAMLFormat(),
+			zabbix.ExportRequestOptionDashboardsID([]string{dashboardIDToExport}),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to export dashboard: %w", err)
+		}
+
+		// Output to file or stdout
+		if dashboardFile != "" {
+			err = os.WriteFile(dashboardFile, []byte(res), 0644)
+			if err != nil {
+				return fmt.Errorf("failed to write dashboard to file: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Dashboard exported to %s\n", dashboardFile)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), res)
+		}
+
+		return nil
+	},
+}

--- a/cmd/dashboard_list.go
+++ b/cmd/dashboard_list.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/sgaunet/zabbix-cli/pkg/zabbix"
+	"github.com/spf13/cobra"
+)
+
+var dashboardOutputFormat string
+
+var DashboardListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Zabbix dashboards",
+	Long:  `List Zabbix dashboards. By default, displays results in a table. Use --output json for raw JSON.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		// initConfig() should be called by cobra.OnInitialize on the RootCmd.
+		// If conf is nil here, it means initConfig was not called or failed.
+		if conf == nil {
+			return fmt.Errorf("configuration not initialized; initConfig did not run or failed")
+		}
+
+		z := zabbix.New(conf.ZabbixUser, conf.ZabbixPassword, conf.ZabbixEndpoint)
+		if err := z.Login(ctx); err != nil {
+			return fmt.Errorf("login failed: %w", err)
+		}
+		defer func() {
+			if err := z.Logout(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "logout failed: %v\n", err)
+			}
+		}()
+
+		// Prepare request to get all dashboards
+		dashboardRequest := zabbix.NewGetAllDashboardsRequest(
+			zabbix.WithDashboardGetAuth(z.Auth()),
+			zabbix.WithDashboardGetID(1), // Simplified ID for CLI context
+		)
+
+		response, err := z.DashboardGet(ctx, dashboardRequest)
+		if err != nil {
+			return fmt.Errorf("failed to get dashboards: %w", err)
+		}
+
+		if dashboardOutputFormat == "json" {
+			jsonOutput, err := json.MarshalIndent(response.Result, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal dashboards to JSON: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), string(jsonOutput))
+		} else {
+			// Table output
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tPRIVATE\tDISPLAY_PERIOD")
+			for _, dashboard := range response.Result {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					dashboard.DashboardID,
+					dashboard.Name,
+					dashboard.Private,
+					dashboard.DisplayPeriod)
+			}
+			w.Flush()
+		}
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,11 @@ var templateName string
 // templateFile is a flag to specify the template file (import)
 var templateFile string
 
+// dashboard-related flags
+var dashboardName string
+var dashboardID string
+var dashboardFile string
+
 var ErrInvalidConfig = errors.New("invalid configuration")
 
 // rootCmd represents the base command when called without any subcommands
@@ -74,6 +79,14 @@ func init() {
 
 	rootCmd.AddCommand(HostgroupCmd)
 	HostgroupCmd.AddCommand(HostGroupGetCmd)
+
+	rootCmd.AddCommand(DashboardCmd)
+	DashboardCmd.AddCommand(DashboardListCmd)
+	DashboardCmd.AddCommand(DashboardExportCmd)
+	DashboardListCmd.Flags().StringVar(&dashboardOutputFormat, "output", "table", "Output format: table or json")
+	DashboardExportCmd.Flags().StringVarP(&dashboardName, "name", "n", "", "Dashboard name to export")
+	DashboardExportCmd.Flags().StringVar(&dashboardID, "id", "", "Dashboard ID to export")
+	DashboardExportCmd.Flags().StringVarP(&dashboardFile, "file", "f", "", "Output file path (default: stdout)")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/zabbix/api.go
+++ b/pkg/zabbix/api.go
@@ -107,6 +107,26 @@ func (z *Client) HostGroupGet(ctx context.Context, request *HostGroupGetRequest)
 	return &response, nil
 }
 
+// DashboardGet sends a dashboard.get request to the Zabbix API.
+// The request object should be fully populated by the caller, including Auth and ID.
+func (z *Client) DashboardGet(ctx context.Context, request *DashboardGetRequest) (*DashboardGetResponse, error) {
+	statusCode, respBody, err := z.postRequest(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed for dashboard.get: %w", err)
+	}
+
+	var response DashboardGetResponse
+	if err := handleRawResponse(statusCode, respBody, "dashboard.get", &response); err != nil {
+		return nil, err
+	}
+
+	if response.Error != nil && response.Error.Code != 0 {
+		return nil, response.Error
+	}
+
+	return &response, nil
+}
+
 // Auth returns the auth token
 // that is used to authenticate.
 // This token is initialized during the login process.

--- a/pkg/zabbix/configuration_export.go
+++ b/pkg/zabbix/configuration_export.go
@@ -19,6 +19,7 @@ type ConfigurationExportOptions struct {
 	MapsID       []string `json:"maps,omitempty"`       // (array) IDs of maps to export.
 	MediaTypesID []string `json:"mediaTypes,omitempty"` // (array) IDs of media types to export.
 	TemplatesID  []string `json:"templates,omitempty"`  // (array) IDs of templates to export.
+	DashboardsID []string `json:"dashboards,omitempty"` // (array) IDs of dashboards to export.
 }
 
 // ConfigurationExportParams is the params struct to export configuration.
@@ -120,6 +121,13 @@ func ExportRequestOptionJSONFormat() ConfigurationExportRequestOption {
 func ExportRequestOptionXMLFormat() ConfigurationExportRequestOption {
 	return func(c *ConfigurationExportRequest) {
 		c.Params.Format = "xml"
+	}
+}
+
+// ExportRequestOptionDashboardsID returns a ConfigurationExportRequestOption for dashboards.
+func ExportRequestOptionDashboardsID(dashboardsID []string) ConfigurationExportRequestOption {
+	return func(c *ConfigurationExportRequest) {
+		c.Params.Options.DashboardsID = dashboardsID
 	}
 }
 

--- a/pkg/zabbix/dashboard-export_test.go
+++ b/pkg/zabbix/dashboard-export_test.go
@@ -1,0 +1,35 @@
+package zabbix
+
+import (
+	"testing"
+)
+
+func TestExportRequestOptionDashboardsID(t *testing.T) {
+	dashboardsID := []string{"1", "2", "3"}
+	req := NewConfigurationExportRequest(ExportRequestOptionDashboardsID(dashboardsID))
+
+	if len(req.Params.Options.DashboardsID) != 3 {
+		t.Errorf("Expected 3 dashboard IDs, got %d", len(req.Params.Options.DashboardsID))
+	}
+	if req.Params.Options.DashboardsID[0] != "1" {
+		t.Errorf("Expected first dashboard ID to be 1, got %s", req.Params.Options.DashboardsID[0])
+	}
+	if req.Params.Options.DashboardsID[1] != "2" {
+		t.Errorf("Expected second dashboard ID to be 2, got %s", req.Params.Options.DashboardsID[1])
+	}
+}
+
+func TestExportRequestOptionDashboardsIDWithYAMLFormat(t *testing.T) {
+	dashboardsID := []string{"42"}
+	req := NewConfigurationExportRequest(
+		ExportRequestOptionDashboardsID(dashboardsID),
+		ExportRequestOptionYAMLFormat(),
+	)
+
+	if req.Params.Options.DashboardsID[0] != "42" {
+		t.Errorf("Expected dashboard ID to be 42, got %s", req.Params.Options.DashboardsID[0])
+	}
+	if req.Params.Format != "yaml" {
+		t.Errorf("Expected format to be yaml, got %s", req.Params.Format)
+	}
+}

--- a/pkg/zabbix/dashboard-get.go
+++ b/pkg/zabbix/dashboard-get.go
@@ -1,0 +1,163 @@
+package zabbix
+
+// DashboardGetParams defines the parameters for the Zabbix dashboard.get API call.
+// See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/get
+type DashboardGetParams struct {
+	CommonGetParams // Embeds common parameters like Output, Limit, Filter, etc.
+
+	DashboardIDs []string `json:"dashboardids,omitempty"` // Return only dashboards with the given IDs.
+
+	SelectPages      interface{} `json:"selectPages,omitempty"`      // Return dashboard pages. "extend" or array of fields
+	SelectUsers      interface{} `json:"selectUsers,omitempty"`      // Return users the dashboard is shared with. "extend" or array of fields
+	SelectUserGroups interface{} `json:"selectUserGroups,omitempty"` // Return user groups the dashboard is shared with. "extend" or array of fields
+}
+
+// DashboardGetRequest defines the JSON-RPC request structure for dashboard.get.
+type DashboardGetRequest struct {
+	JSONRPC string              `json:"jsonrpc"`
+	Method  string              `json:"method"`
+	Params  DashboardGetParams  `json:"params"`
+	Auth    string              `json:"auth,omitempty"`
+	ID      int                 `json:"id"`
+}
+
+// DashboardGetResponse defines the JSON-RPC response structure for dashboard.get.
+type DashboardGetResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Result  []Dashboard `json:"result"` // Array of Dashboard objects
+	ID      int         `json:"id"`
+	Error   *Error      `json:"error,omitempty"`
+}
+
+// DashboardGetOption defines a function signature for options to configure a DashboardGetRequest.
+type DashboardGetOption func(*DashboardGetRequest)
+
+// NewDashboardGetRequest creates a new DashboardGetRequest with default values and applies any provided options.
+func NewDashboardGetRequest(options ...DashboardGetOption) *DashboardGetRequest {
+	dgr := &DashboardGetRequest{
+		JSONRPC: JSONRPC,
+		Method:  "dashboard.get",
+		Params:  DashboardGetParams{}, // Initialize with empty params
+	}
+	for _, opt := range options {
+		opt(dgr)
+	}
+	return dgr
+}
+
+// --- Option functions for DashboardGetParams ---
+
+// WithDashboardGetDashboardIDs sets the dashboard IDs for the request.
+func WithDashboardGetDashboardIDs(ids []string) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.DashboardIDs = ids }
+}
+
+// WithDashboardGetSelectPages sets the selectPages parameter.
+func WithDashboardGetSelectPages(query interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SelectPages = query }
+}
+
+// WithDashboardGetSelectUsers sets the selectUsers parameter.
+func WithDashboardGetSelectUsers(query interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SelectUsers = query }
+}
+
+// WithDashboardGetSelectUserGroups sets the selectUserGroups parameter.
+func WithDashboardGetSelectUserGroups(query interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SelectUserGroups = query }
+}
+
+// --- Option functions for CommonGetParams (embedded) ---
+
+// WithDashboardGetOutput sets the output parameter.
+func WithDashboardGetOutput(output interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.Output = output }
+}
+
+// WithDashboardGetLimit sets the limit parameter.
+func WithDashboardGetLimit(limit int) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.Limit = limit }
+}
+
+// WithDashboardGetFilter sets the filter parameter.
+func WithDashboardGetFilter(filter map[string]interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.Filter = filter }
+}
+
+// WithDashboardGetSortField sets the sortfield parameter.
+func WithDashboardGetSortField(sortField []string) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SortField = sortField }
+}
+
+// WithDashboardGetSortOrder sets the sortorder parameter.
+func WithDashboardGetSortOrder(sortOrder []string) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SortOrder = sortOrder }
+}
+
+// WithDashboardGetSearch sets the search parameter.
+func WithDashboardGetSearch(search map[string]interface{}) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.Search = search }
+}
+
+// WithDashboardGetSearchByAny sets the searchByAny flag.
+func WithDashboardGetSearchByAny(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SearchByAny = flag }
+}
+
+// WithDashboardGetSearchWildcardsEnabled sets the searchWildcardsEnabled flag.
+func WithDashboardGetSearchWildcardsEnabled(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.SearchWildcardsEnabled = flag }
+}
+
+// WithDashboardGetStartSearch sets the startSearch flag.
+func WithDashboardGetStartSearch(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.StartSearch = flag }
+}
+
+// WithDashboardGetExcludeSearch sets the excludeSearch flag.
+func WithDashboardGetExcludeSearch(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.ExcludeSearch = flag }
+}
+
+// WithDashboardGetPreserveKeys sets the preservekeys flag.
+func WithDashboardGetPreserveKeys(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.PreserveKeys = flag }
+}
+
+// WithDashboardGetCountOutput sets the countOutput flag.
+func WithDashboardGetCountOutput(flag bool) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Params.CountOutput = flag }
+}
+
+// --- Option functions for request Auth and ID ---
+
+// WithDashboardGetAuth sets the authentication token for the API request.
+func WithDashboardGetAuth(token string) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.Auth = token }
+}
+
+// WithDashboardGetID sets the ID for the API request.
+func WithDashboardGetID(id int) DashboardGetOption {
+	return func(dgr *DashboardGetRequest) { dgr.ID = id }
+}
+
+// NewGetAllDashboardsRequest creates a DashboardGetRequest configured to fetch all dashboards
+// with all their properties and pages. It allows overriding default auth and ID via options.
+func NewGetAllDashboardsRequest(options ...DashboardGetOption) *DashboardGetRequest {
+	// Define the base options for getting all dashboards
+	baseOptions := []DashboardGetOption{
+		WithDashboardGetOutput("extend"),       // Ensure all fields are fetched for dashboards
+		WithDashboardGetSelectPages("extend"),  // Fetch all pages with widgets
+	}
+
+	// Create a new slice with enough capacity to hold both base and user options
+	allOptions := make([]DashboardGetOption, 0, len(baseOptions)+len(options))
+
+	// Add base options first
+	allOptions = append(allOptions, baseOptions...)
+	// Then add user-provided options which can override base options
+	allOptions = append(allOptions, options...)
+
+	// Use the existing NewDashboardGetRequest constructor with the combined options
+	return NewDashboardGetRequest(allOptions...)
+}

--- a/pkg/zabbix/dashboard-get_test.go
+++ b/pkg/zabbix/dashboard-get_test.go
@@ -1,0 +1,94 @@
+package zabbix
+
+import (
+	"testing"
+)
+
+func TestNewDashboardGetRequest(t *testing.T) {
+	req := NewDashboardGetRequest()
+	if req.JSONRPC != JSONRPC {
+		t.Errorf("Expected JSONRPC to be %s, got %s", JSONRPC, req.JSONRPC)
+	}
+	if req.Method != "dashboard.get" {
+		t.Errorf("Expected Method to be dashboard.get, got %s", req.Method)
+	}
+}
+
+func TestWithDashboardGetDashboardIDs(t *testing.T) {
+	ids := []string{"1", "2", "3"}
+	req := NewDashboardGetRequest(WithDashboardGetDashboardIDs(ids))
+	if len(req.Params.DashboardIDs) != 3 {
+		t.Errorf("Expected 3 dashboard IDs, got %d", len(req.Params.DashboardIDs))
+	}
+	if req.Params.DashboardIDs[0] != "1" {
+		t.Errorf("Expected first dashboard ID to be 1, got %s", req.Params.DashboardIDs[0])
+	}
+}
+
+func TestWithDashboardGetSelectPages(t *testing.T) {
+	req := NewDashboardGetRequest(WithDashboardGetSelectPages("extend"))
+	if req.Params.SelectPages != "extend" {
+		t.Errorf("Expected SelectPages to be extend, got %v", req.Params.SelectPages)
+	}
+}
+
+func TestWithDashboardGetOutput(t *testing.T) {
+	req := NewDashboardGetRequest(WithDashboardGetOutput("extend"))
+	if req.Params.Output != "extend" {
+		t.Errorf("Expected Output to be extend, got %v", req.Params.Output)
+	}
+}
+
+func TestWithDashboardGetAuth(t *testing.T) {
+	token := "test-auth-token"
+	req := NewDashboardGetRequest(WithDashboardGetAuth(token))
+	if req.Auth != token {
+		t.Errorf("Expected Auth to be %s, got %s", token, req.Auth)
+	}
+}
+
+func TestWithDashboardGetID(t *testing.T) {
+	id := 123
+	req := NewDashboardGetRequest(WithDashboardGetID(id))
+	if req.ID != id {
+		t.Errorf("Expected ID to be %d, got %d", id, req.ID)
+	}
+}
+
+func TestWithDashboardGetFilter(t *testing.T) {
+	filter := map[string]interface{}{
+		"name": "test dashboard",
+	}
+	req := NewDashboardGetRequest(WithDashboardGetFilter(filter))
+	if req.Params.Filter["name"] != "test dashboard" {
+		t.Errorf("Expected filter name to be 'test dashboard', got %v", req.Params.Filter["name"])
+	}
+}
+
+func TestNewGetAllDashboardsRequest(t *testing.T) {
+	req := NewGetAllDashboardsRequest()
+	if req.Params.Output != "extend" {
+		t.Errorf("Expected Output to be extend, got %v", req.Params.Output)
+	}
+	if req.Params.SelectPages != "extend" {
+		t.Errorf("Expected SelectPages to be extend, got %v", req.Params.SelectPages)
+	}
+}
+
+func TestNewGetAllDashboardsRequestWithOverrides(t *testing.T) {
+	token := "override-token"
+	id := 999
+	req := NewGetAllDashboardsRequest(
+		WithDashboardGetAuth(token),
+		WithDashboardGetID(id),
+	)
+	if req.Auth != token {
+		t.Errorf("Expected Auth to be %s, got %s", token, req.Auth)
+	}
+	if req.ID != id {
+		t.Errorf("Expected ID to be %d, got %d", id, req.ID)
+	}
+	if req.Params.Output != "extend" {
+		t.Errorf("Expected Output to be extend, got %v", req.Params.Output)
+	}
+}

--- a/pkg/zabbix/dashboard.go
+++ b/pkg/zabbix/dashboard.go
@@ -1,0 +1,50 @@
+package zabbix
+
+// Dashboard represents the Zabbix dashboard API object.
+// See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/object#dashboard
+type Dashboard struct {
+	DashboardID   string          `json:"dashboardid,omitempty"`
+	Name          string          `json:"name"`
+	UserID        string          `json:"userid,omitempty"`        // Owner of the dashboard.
+	Private       string          `json:"private,omitempty"`       // Type of dashboard sharing. 0 - (default) public; 1 - private.
+	DisplayPeriod string          `json:"display_period,omitempty"` // Display period in seconds. Default: 30.
+	AutoStart     string          `json:"auto_start,omitempty"`    // Automatic slideshow. 0 - (default) disabled; 1 - enabled.
+	Pages         []DashboardPage `json:"pages,omitempty"`         // Dashboard pages.
+	Users         []DashboardUser `json:"users,omitempty"`         // Dashboard sharing with users.
+	UserGroups    []DashboardUserGroup `json:"userGroups,omitempty"` // Dashboard sharing with user groups.
+}
+
+// DashboardPage represents a dashboard page.
+// See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/object#dashboard-page
+type DashboardPage struct {
+	DashboardPageID string   `json:"dashboard_pageid,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	DisplayPeriod   string   `json:"display_period,omitempty"` // Page display period in seconds. 0 - default host screen refresh rate. Default: 0.
+	Widgets         []Widget `json:"widgets,omitempty"`        // Dashboard page widgets.
+}
+
+// Widget represents a dashboard widget.
+// See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/object#widget
+type Widget struct {
+	WidgetID string                 `json:"widgetid,omitempty"`
+	Type     string                 `json:"type"`                   // Widget type.
+	Name     string                 `json:"name,omitempty"`         // Widget name.
+	X        string                 `json:"x,omitempty"`            // Widget horizontal position. 0 - leftmost. Default: 0.
+	Y        string                 `json:"y,omitempty"`            // Widget vertical position. 0 - topmost. Default: 0.
+	Width    string                 `json:"width,omitempty"`        // Widget width. Minimum: 1. Maximum: 24. Default: 1.
+	Height   string                 `json:"height,omitempty"`       // Widget height. Minimum: 2. Maximum: 32. Default: 2.
+	View     string                 `json:"view_mode,omitempty"`    // Widget view mode. 0 - (default) normal; 1 - hidden header.
+	Fields   map[string]interface{} `json:"fields,omitempty"`       // Widget configuration fields.
+}
+
+// DashboardUser represents dashboard sharing with a user.
+type DashboardUser struct {
+	UserID     string `json:"userid"`
+	Permission string `json:"permission"` // User permissions. 2 - (default) read-only; 3 - read-write.
+}
+
+// DashboardUserGroup represents dashboard sharing with a user group.
+type DashboardUserGroup struct {
+	UserGroupID string `json:"usrgrpid"`
+	Permission  string `json:"permission"` // User group permissions. 2 - (default) read-only; 3 - read-write.
+}


### PR DESCRIPTION
feat(dashboard): add dashboard list and export commands

Add new dashboard subcommand with list and export functionality:
- Implement dashboard.get API method in Zabbix client
- Add DashboardGet() method to API layer
- Create Dashboard, DashboardPage, and Widget structs
- Add dashboard export support to configuration.export
- Create dashboard list command with table/JSON output
- Create dashboard export command supporting name/ID lookup
- Add comprehensive unit tests for API and export functionality
