### PR TITLE
feat(dashboard): add dashboard filter support to ack and problem commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,11 +65,13 @@ func init() {
 	ProblemGetCmd.Flags().BoolVarP(&Ack, "ack", "a", false, "show acknowledged problems")
 	ProblemGetCmd.Flags().BoolVarP(&Supp, "supp", "s", false, "show suppressed problems")
 	ProblemGetCmd.Flags().StringVar(&problemSeverityFlag, "severity", "", "Filter problems by severity (e.g., 'Not classified', 'Information', 'Warning', 'Average', 'High', 'Disaster')")
+	ProblemGetCmd.Flags().StringVar(&problemDashboardName, "dashboard", "", "Apply filters from named dashboard (extracts filters from first 'problems' widget)")
 	ProblemCmd.AddCommand(ProblemGetCmd)
 	rootCmd.AddCommand(ProblemCmd)
 
 	rootCmd.AddCommand(ackCmd)
 	ackCmd.Flags().StringVar(&ackSeverityFlag, "severity", "", "Filter problems to acknowledge by severity (e.g., 'Not classified', 'Information', 'Warning', 'Average', 'High', 'Disaster')")
+	ackCmd.Flags().StringVar(&ackDashboardName, "dashboard", "", "Apply filters from named dashboard (extracts filters from first 'problems' widget)")
 
 	rootCmd.AddCommand(MaintenanceCmd)
 	MaintenanceCmd.AddCommand(MaintenanceCreateCmd)

--- a/pkg/zabbix/dashboard-filter.go
+++ b/pkg/zabbix/dashboard-filter.go
@@ -1,0 +1,173 @@
+package zabbix
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseProblemsWidgetFilters extracts problem.get API options from a dashboard's problem widgets.
+// It finds the first "problems" type widget in the dashboard and converts its filter fields
+// to GetProblemOption functions that can be used with the GetProblems API call.
+//
+// Returns an empty slice if no problems widget is found or if the widget has no filters.
+// Returns an error if the dashboard is nil or has invalid structure.
+func ParseProblemsWidgetFilters(dashboard *Dashboard) ([]GetProblemOption, error) {
+	if dashboard == nil {
+		return nil, fmt.Errorf("dashboard is nil")
+	}
+
+	// Find the first "problems" widget across all pages
+	widget := findProblemsWidget(dashboard)
+	if widget == nil {
+		// No problems widget found - not an error, just return empty options
+		return []GetProblemOption{}, nil
+	}
+
+	// Parse widget fields into problem options
+	return parseWidgetFieldsToProblemOptions(widget.Fields)
+}
+
+// findProblemsWidget searches for the first widget of type "problems" in the dashboard.
+// Returns nil if no problems widget is found.
+func findProblemsWidget(dashboard *Dashboard) *Widget {
+	for _, page := range dashboard.Pages {
+		for i := range page.Widgets {
+			if page.Widgets[i].Type == "problems" {
+				return &page.Widgets[i]
+			}
+		}
+	}
+	return nil
+}
+
+// parseWidgetFieldsToProblemOptions converts widget fields to problem.get API options.
+// Supports the following field mappings:
+// - groupids → GroupsIDs
+// - hostids → HostsIDs
+// - severities → Severities
+// - tags → Tags with evaltype
+// - show_suppressed → Suppressed
+// - unacknowledged → Acknowledged (inverted)
+func parseWidgetFieldsToProblemOptions(fields []WidgetField) ([]GetProblemOption, error) {
+	var options []GetProblemOption
+
+	// Collect values by field name (some fields can have multiple values)
+	fieldMap := make(map[string][]string)
+	for _, field := range fields {
+		valueStr := fmt.Sprintf("%v", field.Value)
+		fieldMap[field.Name] = append(fieldMap[field.Name], valueStr)
+	}
+
+	// Extract group IDs
+	if groupIDs, ok := fieldMap["groupids"]; ok && len(groupIDs) > 0 {
+		options = append(options, GetProblemOptionGroupsIDs(groupIDs))
+	}
+
+	// Extract host IDs
+	if hostIDs, ok := fieldMap["hostids"]; ok && len(hostIDs) > 0 {
+		options = append(options, GetProblemOptionHostsIDs(hostIDs))
+	}
+
+	// Extract severities
+	if severities, ok := fieldMap["severities"]; ok && len(severities) > 0 {
+		options = append(options, GetProblemOptionSeverities(severities))
+	}
+
+	// Extract tags (more complex structure)
+	tags := extractTags(fields)
+	if len(tags) > 0 {
+		options = append(options, GetProblemOptionTags(tags))
+	}
+
+	// Extract evaltype for tags
+	if evalType, ok := fieldMap["evaltype"]; ok && len(evalType) > 0 {
+		// evaltype: 0 = And/Or, 2 = Or
+		if evalType[0] == "2" {
+			options = append(options, GetProblemOptionEvalType(2))
+		}
+	}
+
+	// Extract show_suppressed flag
+	if showSuppressed, ok := fieldMap["show_suppressed"]; ok && len(showSuppressed) > 0 {
+		// "1" means show suppressed problems
+		if showSuppressed[0] == "1" {
+			options = append(options, GetProblemOptionSuppressed(true))
+		}
+	}
+
+	// Extract unacknowledged flag (note: this is inverted logic)
+	if unacknowledged, ok := fieldMap["unacknowledged"]; ok && len(unacknowledged) > 0 {
+		// "1" means show only unacknowledged (acknowledged=false)
+		if unacknowledged[0] == "1" {
+			options = append(options, GetProblemOptionAcknowledged(false))
+		}
+	}
+
+	return options, nil
+}
+
+// extractTags parses tag-related widget fields into FilterProblemTags structures.
+// Tags in widgets are stored as separate fields with indexed names like:
+// - tags.tag.0, tags.value.0, tags.operator.0
+// - tags.tag.1, tags.value.1, tags.operator.1
+func extractTags(fields []WidgetField) []FilterProblemTags {
+	// Map to collect tag data by index
+	tagMap := make(map[string]*FilterProblemTags) // key: index (e.g., "0", "1")
+
+	for _, field := range fields {
+		if strings.HasPrefix(field.Name, "tags.") {
+			parts := strings.Split(field.Name, ".")
+			if len(parts) != 3 {
+				continue
+			}
+
+			fieldType := parts[1] // "tag", "value", or "operator"
+			index := parts[2]     // "0", "1", "2", etc.
+			valueStr := fmt.Sprintf("%v", field.Value)
+
+			// Initialize tag entry if not exists
+			if tagMap[index] == nil {
+				tagMap[index] = &FilterProblemTags{}
+			}
+
+			// Set the appropriate field
+			switch fieldType {
+			case "tag":
+				tagMap[index].Tag = valueStr
+			case "value":
+				tagMap[index].Value = valueStr
+			case "operator":
+				tagMap[index].Operator = valueStr
+			}
+		}
+	}
+
+	// Convert map to slice
+	var tags []FilterProblemTags
+	for _, tag := range tagMap {
+		// Only include tags that have at least a tag name
+		if tag.Tag != "" {
+			tags = append(tags, *tag)
+		}
+	}
+
+	return tags
+}
+
+// MergeProblemOptions merges two sets of problem options, with priority options taking precedence.
+// This is used to combine dashboard filters with CLI flags, where CLI flags should override
+// dashboard filters for the same parameter.
+//
+// Note: This is a simplified merge that appends all options. For true override behavior,
+// the calling code should conditionally apply dashboard options only if CLI options are not set.
+func MergeProblemOptions(priority []GetProblemOption, dashboard []GetProblemOption) []GetProblemOption {
+	// Start with priority options (usually from CLI flags)
+	merged := make([]GetProblemOption, len(priority))
+	copy(merged, priority)
+
+	// Append dashboard options
+	// Note: The actual problem.get request will use the last value for duplicate parameters
+	merged = append(merged, dashboard...)
+
+	return merged
+}

--- a/pkg/zabbix/dashboard-filter_test.go
+++ b/pkg/zabbix/dashboard-filter_test.go
@@ -1,0 +1,299 @@
+package zabbix
+
+import (
+	"testing"
+)
+
+func TestParseProblemsWidgetFilters_NilDashboard(t *testing.T) {
+	_, err := ParseProblemsWidgetFilters(nil)
+	if err == nil {
+		t.Error("Expected error for nil dashboard, got nil")
+	}
+}
+
+func TestParseProblemsWidgetFilters_NoProblemsWidget(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{Type: "graph"},
+					{Type: "map"},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Errorf("Expected 0 options for dashboard without problems widget, got %d", len(options))
+	}
+}
+
+func TestParseProblemsWidgetFilters_EmptyWidget(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{
+						Type:   "problems",
+						Fields: []WidgetField{},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Errorf("Expected 0 options for empty widget, got %d", len(options))
+	}
+}
+
+func TestParseProblemsWidgetFilters_GroupIDs(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{
+						Type: "problems",
+						Fields: []WidgetField{
+							{Type: "2", Name: "groupids", Value: "4"},
+							{Type: "2", Name: "groupids", Value: "5"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(options) == 0 {
+		t.Error("Expected options for groupids filter")
+	}
+}
+
+func TestParseProblemsWidgetFilters_Severities(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{
+						Type: "problems",
+						Fields: []WidgetField{
+							{Type: "3", Name: "severities", Value: "4"},
+							{Type: "3", Name: "severities", Value: "5"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(options) == 0 {
+		t.Error("Expected options for severities filter")
+	}
+}
+
+func TestParseProblemsWidgetFilters_Tags(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{
+						Type: "problems",
+						Fields: []WidgetField{
+							{Type: "1", Name: "tags.tag.0", Value: "Service"},
+							{Type: "1", Name: "tags.value.0", Value: "Database"},
+							{Type: "0", Name: "tags.operator.0", Value: "0"},
+							{Type: "1", Name: "tags.tag.1", Value: "Environment"},
+							{Type: "1", Name: "tags.value.1", Value: "Production"},
+							{Type: "0", Name: "tags.operator.1", Value: "1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(options) == 0 {
+		t.Error("Expected options for tags filter")
+	}
+}
+
+func TestParseProblemsWidgetFilters_MultipleFilters(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{
+						Type: "problems",
+						Fields: []WidgetField{
+							{Type: "2", Name: "groupids", Value: "4"},
+							{Type: "2", Name: "hostids", Value: "10084"},
+							{Type: "3", Name: "severities", Value: "4"},
+							{Type: "3", Name: "severities", Value: "5"},
+							{Type: "0", Name: "show_suppressed", Value: "1"},
+							{Type: "0", Name: "unacknowledged", Value: "1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := ParseProblemsWidgetFilters(dashboard)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	// Should have at least: groupids, hostids, severities, show_suppressed, unacknowledged
+	if len(options) < 5 {
+		t.Errorf("Expected at least 5 options, got %d", len(options))
+	}
+}
+
+func TestFindProblemsWidget_FirstWidget(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{Type: "problems", Name: "First"},
+					{Type: "problems", Name: "Second"},
+				},
+			},
+		},
+	}
+
+	widget := findProblemsWidget(dashboard)
+	if widget == nil {
+		t.Fatal("Expected to find problems widget")
+	}
+	if widget.Name != "First" {
+		t.Errorf("Expected to find first problems widget, got %s", widget.Name)
+	}
+}
+
+func TestFindProblemsWidget_MultiplePages(t *testing.T) {
+	dashboard := &Dashboard{
+		Pages: []DashboardPage{
+			{
+				Widgets: []Widget{
+					{Type: "graph"},
+				},
+			},
+			{
+				Widgets: []Widget{
+					{Type: "problems", Name: "OnSecondPage"},
+				},
+			},
+		},
+	}
+
+	widget := findProblemsWidget(dashboard)
+	if widget == nil {
+		t.Fatal("Expected to find problems widget")
+	}
+	if widget.Name != "OnSecondPage" {
+		t.Errorf("Expected to find problems widget on second page, got %s", widget.Name)
+	}
+}
+
+func TestExtractTags_ValidTags(t *testing.T) {
+	fields := []WidgetField{
+		{Type: "1", Name: "tags.tag.0", Value: "Service"},
+		{Type: "1", Name: "tags.value.0", Value: "Database"},
+		{Type: "0", Name: "tags.operator.0", Value: "0"},
+		{Type: "1", Name: "tags.tag.1", Value: "Environment"},
+		{Type: "1", Name: "tags.value.1", Value: "Production"},
+		{Type: "0", Name: "tags.operator.1", Value: "1"},
+	}
+
+	tags := extractTags(fields)
+	if len(tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(tags))
+	}
+
+	// Check first tag
+	foundTag0 := false
+	for _, tag := range tags {
+		if tag.Tag == "Service" && tag.Value == "Database" && tag.Operator == "0" {
+			foundTag0 = true
+			break
+		}
+	}
+	if !foundTag0 {
+		t.Error("Expected to find Service=Database tag with operator 0")
+	}
+
+	// Check second tag
+	foundTag1 := false
+	for _, tag := range tags {
+		if tag.Tag == "Environment" && tag.Value == "Production" && tag.Operator == "1" {
+			foundTag1 = true
+			break
+		}
+	}
+	if !foundTag1 {
+		t.Error("Expected to find Environment=Production tag with operator 1")
+	}
+}
+
+func TestExtractTags_IncompleteTag(t *testing.T) {
+	fields := []WidgetField{
+		{Type: "1", Name: "tags.tag.0", Value: "Service"},
+		// Missing value and operator for index 0
+		{Type: "1", Name: "tags.tag.1", Value: "Environment"},
+		{Type: "1", Name: "tags.value.1", Value: "Production"},
+	}
+
+	tags := extractTags(fields)
+	// Should include both tags even if incomplete
+	if len(tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(tags))
+	}
+}
+
+func TestExtractTags_NoTags(t *testing.T) {
+	fields := []WidgetField{
+		{Type: "2", Name: "groupids", Value: "4"},
+		{Type: "3", Name: "severities", Value: "5"},
+	}
+
+	tags := extractTags(fields)
+	if len(tags) != 0 {
+		t.Errorf("Expected 0 tags, got %d", len(tags))
+	}
+}
+
+func TestMergeProblemOptions(t *testing.T) {
+	priority := []GetProblemOption{
+		GetProblemOptionSeverities([]string{"5"}),
+	}
+	dashboard := []GetProblemOption{
+		GetProblemOptionGroupsIDs([]string{"4"}),
+		GetProblemOptionSeverities([]string{"3", "4"}),
+	}
+
+	merged := MergeProblemOptions(priority, dashboard)
+
+	// Should have 3 options total (1 from priority + 2 from dashboard)
+	if len(merged) != 3 {
+		t.Errorf("Expected 3 merged options, got %d", len(merged))
+	}
+}

--- a/pkg/zabbix/dashboard.go
+++ b/pkg/zabbix/dashboard.go
@@ -26,15 +26,23 @@ type DashboardPage struct {
 // Widget represents a dashboard widget.
 // See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/object#widget
 type Widget struct {
-	WidgetID string                 `json:"widgetid,omitempty"`
-	Type     string                 `json:"type"`                   // Widget type.
-	Name     string                 `json:"name,omitempty"`         // Widget name.
-	X        string                 `json:"x,omitempty"`            // Widget horizontal position. 0 - leftmost. Default: 0.
-	Y        string                 `json:"y,omitempty"`            // Widget vertical position. 0 - topmost. Default: 0.
-	Width    string                 `json:"width,omitempty"`        // Widget width. Minimum: 1. Maximum: 24. Default: 1.
-	Height   string                 `json:"height,omitempty"`       // Widget height. Minimum: 2. Maximum: 32. Default: 2.
-	View     string                 `json:"view_mode,omitempty"`    // Widget view mode. 0 - (default) normal; 1 - hidden header.
-	Fields   map[string]interface{} `json:"fields,omitempty"`       // Widget configuration fields.
+	WidgetID string        `json:"widgetid,omitempty"`
+	Type     string        `json:"type"`                // Widget type.
+	Name     string        `json:"name,omitempty"`      // Widget name.
+	X        string        `json:"x,omitempty"`         // Widget horizontal position. 0 - leftmost. Default: 0.
+	Y        string        `json:"y,omitempty"`         // Widget vertical position. 0 - topmost. Default: 0.
+	Width    string        `json:"width,omitempty"`     // Widget width. Minimum: 1. Maximum: 24. Default: 1.
+	Height   string        `json:"height,omitempty"`    // Widget height. Minimum: 2. Maximum: 32. Default: 2.
+	View     string        `json:"view_mode,omitempty"` // Widget view mode. 0 - (default) normal; 1 - hidden header.
+	Fields   []WidgetField `json:"fields,omitempty"`    // Widget configuration fields.
+}
+
+// WidgetField represents a single configuration field in a dashboard widget.
+// See: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/dashboard/object#widget-field
+type WidgetField struct {
+	Type  string      `json:"type"`            // Field type (determines how value is interpreted).
+	Name  string      `json:"name"`            // Field name (e.g., "groupids", "severities", "tags").
+	Value interface{} `json:"value,omitempty"` // Field value (can be string, int, or complex structure depending on field type).
 }
 
 // DashboardUser represents dashboard sharing with a user.


### PR DESCRIPTION
feat(dashboard): add dashboard filter support to ack and problem commands

Enable ack and problem get commands to apply filters from dashboard widgets:
- Add ParseProblemsWidgetFilters() to extract filters from dashboard
- Update Widget.Fields type to support proper field parsing
- Add --dashboard flag to ack command
- Add --dashboard flag to problem get command
- Support widget filters: groupids, hostids, severities, tags, suppressed, acknowledged
- CLI flags override dashboard filters when both specified
- Add comprehensive unit tests for filter parsing
